### PR TITLE
Server can execute every .js, added css and Ctrl^C

### DIFF
--- a/start-demo-server.py
+++ b/start-demo-server.py
@@ -10,14 +10,20 @@ class demoAppHandler(BaseHTTPRequestHandler):
 	def do_GET(self):
 		if self.path=="/": self.path="/demo/index.html"
 		sendReply = False
-		if self.path.endswith(".html"):
+		if self.path.endswith(".html"):			
 			mimetype='text/html'
 			sendReply = True
-		if self.path.endswith(".js"):
-			self.path="/demo/demo-application.js"
+		if self.path.endswith(".js"):                        
+			if "demo" in self.path:
+				self.path = "/demo" + self.path
 			mimetype='application/javascript'
 			sendReply = True
-		
+		if self.path.endswith(".css"):                        
+			if "demo" in self.path:
+				self.path = "/demo" + self.path
+			mimetype='text/css'
+			sendReply = True
+
 		if sendReply == True:
 			f = open(curdir + sep + self.path) 
 			self.send_response(200)
@@ -28,7 +34,12 @@ class demoAppHandler(BaseHTTPRequestHandler):
 		return
 
 
-httpd = HTTPServer(('', PORT), demoAppHandler)
+try:
 
-print 'Serving at port:', PORT
-httpd.serve_forever()
+	httpd = HTTPServer(('', PORT), demoAppHandler)
+
+	print 'Serving at port:', PORT
+	httpd.serve_forever()
+
+except KeyboardInterrupt:
+	print '\nThanks for trying long-press, hope you like it!\nIf you have any problem visit https://github.com/ruzpuz/long-press'


### PR DESCRIPTION
Added:
- [x] Server is not anymore limited to `demo-application.js`, it is able to execute any `.js` file.
- [x] Server can return `.css` files
- [x] Stopping it with Ctrl+C will return message instead of generic error:

```
Thanks for trying long-press, hope you like it!
If you have any problem visit https://github.com/ruzpuz/long-press
```

Tested server myself, looks like it is working pretty correctly. :+1: :)
